### PR TITLE
Fixing the same browser language toggle.

### DIFF
--- a/bot/virtualAssistantBot.js
+++ b/bot/virtualAssistantBot.js
@@ -1,4 +1,5 @@
 const { ActivityHandler, MessageFactory } = require('botbuilder');
+const { setLocale } = require('../dialogs/unblockbot/locales/i18nConfig');
 // const { WaterfallDialog, WaterfallStepContext, ChoicePrompt, TextPrompt, DialogTurnStatus } = require('botbuilder-dialogs');
 const { MainDialog } = require('../dialogs/unblockbot/mainDialog');
 
@@ -31,8 +32,9 @@ class VirtualAssistantBot extends ActivityHandler {
         
 
         this.onMembersAdded(async (context, next) => {
-            console.log('Running dialog with Message Activity.');
+            console.log('MEMBER ADDED: Running dialog with Message Activity.');
 
+            setLocale(context.activity.locale);
             // Send greeting and then activate dialog
             // await context.sendActivity(`Hi Mary, I’m your virtual concierge!`);
 
@@ -45,7 +47,8 @@ class VirtualAssistantBot extends ActivityHandler {
 
         this.onMessage(async (context, next) => {
             
-            console.log('Running dialog with Message Activity.');
+            console.log('ON MESSAGE: Running dialog with Message Activity.');
+            setLocale(context.activity.locale);
 
             // Run the Dialog with the new message Activity.
             await this.dialog.run(context, this.dialogState);

--- a/dialogs/unblockbot/confirmLookIntoStep.js
+++ b/dialogs/unblockbot/confirmLookIntoStep.js
@@ -8,7 +8,7 @@ const {
 const { LuisRecognizer } = require('botbuilder-ai');
 
 // This is for the i18n stuff
-const { i18n, setLocale } = require('./locales/i18nConfig');
+const { i18n } = require('./locales/i18nConfig');
 
 const TEXT_PROMPT = 'TEXT_PROMPT';
 const CONFIRM_LOOK_INTO_STEP = 'CONFIRM_LOOK_INTO_STEP';
@@ -46,9 +46,6 @@ class ConfirmLookIntoStep extends ComponentDialog {
     async initialStep(stepContext) {
         // Get the user details / state machine
         const unblockBotDetails = stepContext.options;
-
-        // This sets the i18n local in a helper function 
-        setLocale(stepContext.context.activity.locale);
 
         // DEBUG
         // console.log('DEBUG UNBLOCKBOTDETAILS:', unblockBotDetails);

--- a/dialogs/unblockbot/confirmNotifyROEReceivedStep.js
+++ b/dialogs/unblockbot/confirmNotifyROEReceivedStep.js
@@ -8,7 +8,7 @@ const {
 const { LuisRecognizer } = require('botbuilder-ai');
 
 // This is for the i18n stuff
-const { i18n, setLocale } = require('./locales/i18nConfig');
+const { i18n } = require('./locales/i18nConfig');
 
 const TEXT_PROMPT = 'TEXT_PROMPT';
 const CONFIRM_NOTIFY_ROE_RECEIVED_STEP = 'CONFIRM_NOTIFY_ROE_RECEIVED_STEP';

--- a/dialogs/unblockbot/confirmSendEmailStep.js
+++ b/dialogs/unblockbot/confirmSendEmailStep.js
@@ -8,7 +8,7 @@ const {
 const { LuisRecognizer } = require('botbuilder-ai');
 
 // This is for the i18n stuff
-const { i18n, setLocale } = require('./locales/i18nConfig');
+const { i18n } = require('./locales/i18nConfig');
 
 const TEXT_PROMPT = 'TEXT_PROMPT';
 const CONFIRM_SEND_EMAIL_STEP = 'CONFIRM_SEND_EMAIL_STEP';
@@ -48,9 +48,6 @@ class ConfirmSendEmailStep extends ComponentDialog {
 
         // DEBUG
         // console.log('DEBUG UNBLOCKBOTDETAILS:', unblockBotDetails.errorCount.confirmSendEmailStep);
-
-        // This sets the i18n local in a helper function 
-        setLocale(stepContext.context.activity.locale);
 
         // Set the text for the prompt
         const standardMsg = i18n.__('confirmSendEmailStepStandardMsg');

--- a/dialogs/unblockbot/getAndSendEmailStep.js
+++ b/dialogs/unblockbot/getAndSendEmailStep.js
@@ -5,7 +5,7 @@ const {
 } = require('botbuilder-dialogs');
 
 // This is for the i18n stuff
-const { i18n, setLocale } = require('./locales/i18nConfig');
+const { i18n } = require('./locales/i18nConfig');
 
 const TEXT_PROMPT = 'TEXT_PROMPT';
 const GET_AND_SEND_EMAIL_STEP = 'GET_AND_SEND_EMAIL_STEP';

--- a/dialogs/unblockbot/getPreferredMethodOfContactStep.js
+++ b/dialogs/unblockbot/getPreferredMethodOfContactStep.js
@@ -8,7 +8,7 @@ const {
 const { LuisRecognizer } = require('botbuilder-ai');
 
 // This is for the i18n stuff
-const { i18n, setLocale } = require('./locales/i18nConfig');
+const { i18n } = require('./locales/i18nConfig');
 
 const TEXT_PROMPT = 'TEXT_PROMPT';
 const GET_PREFFERED_METHOD_OF_CONTACT_STEP = 'GET_PREFFERED_METHOD_OF_CONTACT_STEP';
@@ -45,9 +45,6 @@ class GetPreferredMethodOfContactStep extends ComponentDialog {
     async initialStep(stepContext) {
         // Get the user details / state machine
         const unblockBotDetails = stepContext.options;
-
-         // This sets the i18n local in a helper function 
-         setLocale(stepContext.context.activity.locale);
 
         // DEBUG
         // console.log('DEBUG UNBLOCKBOTDETAILS:', unblockBotDetails);

--- a/dialogs/unblockbot/mainDialog.js
+++ b/dialogs/unblockbot/mainDialog.js
@@ -18,7 +18,7 @@ const {
 const { UnblockBotDetails } = require('./unblockBotDetails');
 
 // This is for the i18n stuff
-const { i18n, setLocale } = require('./locales/i18nConfig');
+const { i18n } = require('./locales/i18nConfig');
 
 
 const CHOICE_PROMPT = 'CHOICE_PROMPT';
@@ -67,8 +67,6 @@ class MainDialog extends ComponentDialog {
      * Initial step in the waterfall. This will kick of the unblockbot dialog
      */
     async initialStep(stepContext) {
-         // This sets the i18n local in a helper function 
-         setLocale(stepContext.context.activity.locale);
 
         const unblockBotDetails = new UnblockBotDetails();
         return await stepContext.beginDialog(UNBLOCK_BOT_DIALOG, unblockBotDetails);

--- a/dialogs/unblockbot/unblockBotDialog.js
+++ b/dialogs/unblockbot/unblockBotDialog.js
@@ -10,7 +10,7 @@ const { ConfirmNotifyROEReceivedStep, CONFIRM_NOTIFY_ROE_RECEIVED_STEP } = requi
 const { GetPreferredMethodOfContactStep, GET_PREFFERED_METHOD_OF_CONTACT_STEP } = require('./getPreferredMethodOfContactStep');
 
 // This is for the i18n stuff
-const { i18n, setLocale } = require('./locales/i18nConfig');
+const { i18n } = require('./locales/i18nConfig');
 
 const UNBLOCK_BOT_DIALOG = 'UNBLOCK_BOT_DIALOG';
 const MAIN_UNBLOCK_BOT_WATERFALL_DIALOG = 'MAIN_UNBLOCK_BOT_WATERFALL_DIALOG';
@@ -50,9 +50,6 @@ class UnblockBotDialog extends ComponentDialog {
 
         // Get the unblockbot details / state machine for the current user
         const unblockBotDetails = stepContext.options;
-
-        // This sets the i18n local in a helper function 
-        setLocale(stepContext.context.activity.locale);
          
         const welcomeMsg = i18n.__('unBlockBotDialogWelcomeMsg');
 


### PR DESCRIPTION
## Description

Changed where we set the locale to when a new member is added to the conversation and on every message.

this should solve the issue for when the same browser has 2 chats opened, the language toggle should not affect each other.

## How to test
Open two emulators side by side and play around with the locales and send messages.